### PR TITLE
Update expirtations action sets fields to null instead of true

### DIFF
--- a/inventory/actions/service/subscription/update-expirations.php
+++ b/inventory/actions/service/subscription/update-expirations.php
@@ -28,7 +28,7 @@ $should_be_expired_ids = Subscription::search([
 
 if (!empty($should_be_expired_ids)) {
     Subscription::ids($should_be_expired_ids)
-        ->update(['is_expired' => true]);
+        ->update(['is_expired' => null]);
 }
 
 $should_be_upcoming_expiry_ids = Subscription::search([
@@ -39,7 +39,7 @@ $should_be_upcoming_expiry_ids = Subscription::search([
 
 if (!empty($should_be_upcoming_expiry_ids)) {
     Subscription::ids($should_be_upcoming_expiry_ids)
-        ->update(['has_upcoming_expiry' => true]);
+        ->update(['has_upcoming_expiry' => null]);
 }
 
 $context->httpResponse()


### PR DESCRIPTION
As discussed, it is better that the cron update-expirations sets the fields to null instead of true, so that logic of true or false is only in the class.

You can run the tests to check that it still works:
`./equal.run --do=test_package --package=inventory`